### PR TITLE
Ascend* & Descend* results should be limited by the item's value when an index is provided

### DIFF
--- a/buntdb.go
+++ b/buntdb.go
@@ -1230,8 +1230,13 @@ func (tx *Tx) scan(
 	// create some limit items
 	var itemA, itemB *dbItem
 	if gt || lt {
-		itemA = &dbItem{key: start}
-		itemB = &dbItem{key: stop}
+		if index == "" {
+			itemA = &dbItem{key: start}
+			itemB = &dbItem{key: stop}
+		} else {
+			itemA = &dbItem{val: start}
+			itemB = &dbItem{val: stop}
+		}
 	}
 	// execute the scan on the underlying tree.
 	if desc {


### PR DESCRIPTION
Ascend* & Descend* results should be limited by the item's value when an index is provided.