### PR TITLE
Adding OnExpiredSync Callback

### DIFF
--- a/buntdb.go
+++ b/buntdb.go
@@ -121,6 +121,12 @@ type Config struct {
 	// OnExpired is used to custom handle the deletion option when a key
 	// has been expired.
 	OnExpired func(keys []string)
+
+	// OnExpiredSync will be called inside the same transaction that is performing
+	// the deletion of expired items. If OnExpired is present then this callback
+	// will not be called. If this callback is present, then the deletion of the
+	// timeed-out item is the explicit responsibility of this callback.
+	OnExpiredSync func(key, value string, tx *Tx) error
 }
 
 // exctx is a simple b-tree context for ordering by expiration.
@@ -544,9 +550,13 @@ func (db *DB) backgroundManager() {
 		// Open a standard view. This will take a full lock of the
 		// database thus allowing for access to anything we need.
 		var onExpired func([]string)
-		var expired []string
+		var expired []*dbItem
+		var onExpiredSync func(key, value string, tx *Tx) error
 		err := db.Update(func(tx *Tx) error {
 			onExpired = db.config.OnExpired
+			if onExpired == nil {
+				onExpiredSync = db.config.OnExpiredSync
+			}
 			if db.persist && !db.config.AutoShrinkDisabled {
 				pos, err := db.file.Seek(0, 1)
 				if err != nil {
@@ -562,18 +572,24 @@ func (db *DB) backgroundManager() {
 			db.exps.AscendLessThan(&dbItem{
 				opts: &dbItemOpts{ex: true, exat: time.Now()},
 			}, func(item btree.Item) bool {
-				expired = append(expired, item.(*dbItem).key)
+				expired = append(expired, item.(*dbItem))
 				return true
 			})
-			if onExpired == nil {
-				for _, key := range expired {
-					if _, err := tx.Delete(key); err != nil {
+			if onExpired == nil && onExpiredSync == nil {
+				for _, itm := range expired {
+					if _, err := tx.Delete(itm.key); err != nil {
 						// it's ok to get a "not found" because the
 						// 'Delete' method reports "not found" for
 						// expired items.
 						if err != ErrNotFound {
 							return err
 						}
+					}
+				}
+			} else if onExpiredSync != nil {
+				for _, itm := range expired {
+					if err := onExpiredSync(itm.key, itm.val, tx); err != nil {
+						return err
 					}
 				}
 			}
@@ -585,7 +601,11 @@ func (db *DB) backgroundManager() {
 
 		// send expired event, if needed
 		if onExpired != nil && len(expired) > 0 {
-			onExpired(expired)
+			keys := make([]string, 0, 32)
+			for _, itm := range expired {
+				keys = append(keys, itm.key)
+			}
+			onExpired(keys)
 		}
 
 		// execute a disk sync, if needed
@@ -1399,13 +1419,18 @@ func (tx *Tx) Set(key, value string, opts *SetOptions) (previousValue string,
 }
 
 // Get returns a value for a key. If the item does not exist or if the item
-// has expired then ErrNotFound is returned.
-func (tx *Tx) Get(key string) (val string, err error) {
+// has expired then ErrNotFound is returned. If ignoreExpired is true, then
+// the found value will be returned even if it is expired.
+func (tx *Tx) Get(key string, ignoreExpired ...bool) (val string, err error) {
 	if tx.db == nil {
 		return "", ErrTxClosed
 	}
+	var ignore bool
+	if len(ignoreExpired) != 0 {
+		ignore = ignoreExpired[0]
+	}
 	item := tx.db.get(key)
-	if item == nil || item.expired() {
+	if item == nil || (item.expired() && !ignore) {
 		// The item does not exists or has expired. Let's assume that
 		// the caller is only interested in items that have not expired.
 		return "", ErrNotFound


### PR DESCRIPTION
`OnExpiredSync` callback is added to `Config` - #32 .

> `OnExpiredSync` will be called inside the same transaction that is performing
> the deletion of expired items. If `OnExpired` is present then this callback
> will not be called. If this callback is present, then the deletion of the
> timeed-out item is the explicit responsibility of this callback.
> 

Optional boolean parameter `ignoreExpired` added to `*Tx.Get(key string, ignoreExpired ...bool)` to see the item even if it's expired. It does not break the API. This option is useful in sliding timeout scenarios.

> Get returns a value for a key. If the item does not exist or if the item
> has expired then ErrNotFound is returned. If ignoreExpired is true, then
> the found value will be returned even if it is expired.