### PR TITLE
Add support for explicit Sync

### DIFF
--- a/buntdb.go
+++ b/buntdb.go
@@ -628,6 +628,20 @@ func (db *DB) backgroundManager() {
 	}
 }
 
+// Sync will synchronously persist the database file to disk. This
+// should only be used when [SyncPolicy] is set to [Never].
+func (db *DB) Sync() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if db.closed {
+		return ErrDatabaseClosed
+	}
+	if !db.persist {
+		return nil
+	}
+	return db.file.Sync()
+}
+
 // Shrink will make the database file smaller by removing redundant
 // log entries. This operation does not block the database.
 func (db *DB) Shrink() error {


### PR DESCRIPTION
This PR adds one new public method `buntdb.(*DB).Sync`

## WAL Compaction

I'd like to use BuntDB with `SyncPolicy: Never` as an on-disk state machine behind a Raft proposal log. The raft log acts as a [WAL](https://en.wikipedia.org/wiki/Write-ahead_logging) and the raft library calls [Sync](https://pkg.go.dev/github.com/lni/dragonboat/v4@v4.0.0-20230202152124-023bafb8e648/statemachine#:~:text=%2F%2F%20Sync%20) explicitly on the state machine during WAL compaction. 

Without an explicit `Sync` operation in BuntDB, it's not possible to guarantee write durability. If the WAL is truncated and some updates have not yet been flushed to disk, a crash could cause unsynced writes to be discarded, causing the state machine to become unrecoverable.

## Similar To

- See [lmdb.(*Env).Sync](https://pkg.go.dev/github.com/bmatsuo/lmdb-go/lmdb#Env.Sync)
- See [pebble.(*DB).Flush](https://pkg.go.dev/github.com/cockroachdb/pebble#DB.Flush)
- See [bbolt.(*DB).Sync](https://pkg.go.dev/github.com/etcd-io/bbolt?utm_source=godoc#DB.Sync)