### PR TITLE
ido/fix crash on windows

### DIFF
--- a/buntdb_test.go
+++ b/buntdb_test.go
@@ -46,7 +46,7 @@ func testClose(db *DB) {
 	_ = os.RemoveAll("data.db")
 }
 
-func TestBackgroudOperations(t *testing.T) {
+func TestBackgroundOperations(t *testing.T) {
 	db := testOpen(t)
 	defer testClose(db)
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
During Shrink, we try to move the temporary file which was created to the database's original location,
this may fail on windows because if you try to rename a file to a name that already exists, the operation will fail with an  "Access is denied" error (while succeed and overwrite the file on mac and linux).

Additionally, fixed a small typo in test
